### PR TITLE
Set multiple elements at once

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,19 +54,63 @@ import set from 'immutable-set';
 Then set the property you want in your object
 
 ```js
-const newState = set(state, ['a', 0, 'b'], 42, true);
+const newState = set(state, ['a', 'b'], 42);
 // or
-const newState = set(state, 'a[0].b', 42, true);
+const newState = set(state, 'a.b', 42);
 /*
  newState => {
-               a: [
-                 {
-                   b: 42,
-                 },
-               ],
+               a: {
+                 b: 42,
+               },
                ...
              }
  */
 ```
 
-The function mutates the object only if the value is not already present in the object
+The function mutates the object only if the value is not already present in the object.
+
+## Advanced usage
+
+### with arrays
+The option `withArrays` allow to dynamically create arrays when the current level is empty and the current path key is a number.
+```js
+let base = set({}, ['a', 0], 12, { withArrays: true });
+// will return { a: [12] }
+```
+
+### safe
+The option `safe` will verify if the value is not already in the object.
+```js
+const base = { a: 2 };
+set(base, 'a', 2, { safe: true })
+// will return the base unmodified
+```
+
+### equality
+The option `equality` allow to use an other equality function instead of `===`. It has to be used with `safe` option.
+```js
+const base = { a: { id: 1, v: 0 } };
+const equality = (a, b) => a.id === b.id && a.v === b.v };
+
+set(base, 'a', { id: 1, v: 0 }, { safe: true, equality);
+// will return the base unmodified
+
+set(base, 'a', { id: 1, v: 1 }, { safe: true, equality);
+// will return { a: { id: 1, v: 1 } }
+```
+
+### multiple set
+It is possible to set multiple elements at once, providing multiple keys in the path and an array (or an object) in value.
+```js
+set({}, ['a', ['b', 'c']], [12, 13]);
+// or
+set({}, ['a', ['b', 'c']], { b: 12, c: 13 });
+// will return { a: { b: 12, c: 13 } }
+
+
+set({}, ['a', [0, 1 ]], [12, 13], { withArrays: true });
+// will return { a: [12, 13] }
+```
+- :warning: If the array of keys is not the last element of the path, the rest of the path will be used for each sub tree.
+- :warning: It's not possible to set objects in array with object sub values, this will throw an error.
+- :warning: For now safe mode does not work with multiple set.

--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ name | description | type | default
 ---- | ----------- | ---- | -------
 withArray | if set to `true` number will be interpreted has array indexes | boolean | false
 equality  | if provided, the function will be used to determine if the value at the path is equal to the value provided | function | `===`
+safe | verify if the value does not already exist | boolean | false
 
 
 ## Usage

--- a/README.md
+++ b/README.md
@@ -29,13 +29,19 @@ yarn add immutable-set
 
 ## Parameters
 
+name | description | type | requiered
+---- | ----------- | ---- | ---------
+base | object to modify | object | ✅
+path | list of keys to access the value to being modified | array or string | ✅
+value | value to set | any | ✅
+options | options... | object
+
+### Options
 name | description | type | default
 ---- | ----------- | ---- | -------
-base | object to modify | object
-path | list of keys to access the value to being modified | array or string
-value | value to set | any
-withArray (optional)| if set to `true` number will be interpreted has array indexes | boolean | false
-equality (optional) | if provided, the function will be used to determine if the value at the path is equal to the value provided | function | `===`
+withArray | if set to `true` number will be interpreted has array indexes | boolean | false
+equality  | if provided, the function will be used to determine if the value at the path is equal to the value provided | function | `===`
+
 
 ## Usage
 Import `set` function

--- a/src/set.js
+++ b/src/set.js
@@ -42,7 +42,8 @@ function set(base, path, value, withArrays) {
   };
 }
 
-export default function safeSet(base, initialPath, value, withArrays = false, equality) {
+export default function safeSet(base, initialPath, value, options = {}) {
+  const { withArrays = false, equality } = options;
   let path = initialPath;
 
   if (typeof path === 'string' && path.length > 0) {

--- a/src/set.js
+++ b/src/set.js
@@ -1,3 +1,11 @@
+/**
+ * Recursive equality tester. Return true if the top down element of the path in the base is equal to the given value
+ * @param base current base
+ * @param path current path
+ * @param value value to verify
+ * @param equality override the equality assertion
+ * @returns {boolean} true if the value is in the base at the end of the path
+ */
 function recursiveEqual(base, path, value, equality) {
   if (!base || typeof base !== 'object') {
     return false;
@@ -11,41 +19,139 @@ function recursiveEqual(base, path, value, equality) {
   return recursiveEqual(base[key], path.slice(1), value, equality);
 }
 
+/**
+ * Compute next base in recursion
+ * @param base current base
+ * @param key current key in the path
+ * @param nextKey next key in the path
+ * @param withArrays create arrays instead of object when nextKey is a number and key has no value in the current base
+ */
+const nextBase = (base, key, nextKey, withArrays) => base[key] || (withArrays && typeof nextKey === 'number' ? [] : {});
+
+/**
+ * Reduce multiple elements in the accumulator using the setFunction when base is an Array
+ * @param setFunction
+ */
+const reduceWithArray = setFunction =>
+  /**
+   * Reduce multiple elements in the accumulator
+   * @param base current base
+   * @param path current path
+   * @param keys list of keys ; we know there that keys is an array or set
+   * @param nextKey next key in the path
+   * @param values list of values, has to be an array
+   * @param withArrays
+   * @param accumulator new instance of the array at the current level
+   * @returns {*} the accumulator with the new elements
+   */
+  (base, path, keys, nextKey, values, withArrays, accumulator) => {
+    if (!Array.isArray(values)) {
+      throw new Error('Can not use object values with array in path');
+    }
+
+    return keys.reduce((acc, key, index) => {
+      const newValue = setFunction(nextBase(base, key, nextKey, withArrays), path.slice(1), values[index], withArrays);
+
+      if (key < acc.length) {
+        acc[key] = newValue;
+      } else {
+        acc.push(newValue);
+      }
+
+      return acc;
+    }, accumulator);
+  };
+
+/**
+ * Reduce multiple elements in an new Object using the setFunction when base is an Object
+ * @param setFunction
+ */
+const reduceWithObject = fn =>
+  /**
+   * Reduce multiple elements in an new Object
+   * @param base current base
+   * @param path current path
+   * @param keys list of keys ; we know there that keys is an array or set
+   * @param nextKey next key in the path
+   * @param values list of values, could be an array or an object
+   * @param withArrays
+   * @returns {*} a set of the new elements
+   */
+  (base, path, keys, nextKey, values, withArrays) => {
+    if (Array.isArray(values)) {
+      return keys.reduce((acc, key, index) => {
+        acc[key] = fn(nextBase(base, key, nextKey, withArrays), path.slice(1), values[index], withArrays);
+
+        return acc;
+      }, {});
+    }
+
+    return keys.reduce((acc, key) => {
+      acc[key] = fn(nextBase(base, key, nextKey, withArrays), path.slice(1), values[key], withArrays);
+
+      return acc;
+    }, {});
+  };
+
+/**
+ * Recursive immutable set
+ * @param base current base
+ * @param path current path
+ * @param value current value
+ * @param withArrays create arrays instead of object when nextKey is a number and key has no value in the current base
+ * @returns {*} a new instance of the given level
+ */
 function set(base, path, value, withArrays) {
   if (path.length === 0) {
     return value;
   }
 
   const [key, nextKey] = path;
-
+  const isArrayKeys = Array.isArray(key);
   let currentBase = base;
+
   if (!base || typeof base !== 'object') {
-    currentBase = withArrays && typeof key === 'number' ? [] : {};
+    currentBase = (isArrayKeys && typeof key[0] === 'number') || (withArrays && typeof key === 'number') ? [] : {};
+  }
+
+  if (isArrayKeys) {
+    if (Array.isArray(currentBase)) {
+      return reduceWithArray(set)(currentBase, path, key, nextKey, value, withArrays, [...currentBase]);
+    }
+
+    return {
+      ...currentBase,
+      ...reduceWithObject(set)(currentBase, path, key, nextKey, value, withArrays, {}),
+    };
   }
 
   if (Array.isArray(currentBase)) {
     return [
       ...currentBase.slice(0, key),
-      set(currentBase[key] || (withArrays && typeof nextKey === 'number' ? [] : {}), path.slice(1), value, withArrays),
+      set(nextBase(currentBase, key, nextKey, withArrays), path.slice(1), value, withArrays),
       ...currentBase.slice(key + 1),
     ];
   }
 
   return {
     ...currentBase,
-    [key]: set(
-      currentBase[key] || (withArrays && typeof nextKey === 'number' ? [] : {}),
-      path.slice(1),
-      value,
-      withArrays,
-    ),
+    [key]: set(nextBase(currentBase, key, nextKey, withArrays), path.slice(1), value, withArrays),
   };
 }
 
+/**
+ * Main function, recursive immutable set
+ * @param base base object
+ * @param initialPath path to the place where the value is going to be set
+ * @param value value to set
+ * @param options options
+ * @returns {*} new instance of the base if it has been modified, the base otherwise
+ */
 export default function safeSet(base, initialPath, value, options = {}) {
   const { withArrays = false, equality, safe } = options;
   let path = initialPath;
 
+  // Handle string path
   if (typeof path === 'string' && path.length > 0) {
     path = path.split('.');
     path = path.reduce((acc, key) => {

--- a/src/set.js
+++ b/src/set.js
@@ -43,7 +43,7 @@ function set(base, path, value, withArrays) {
 }
 
 export default function safeSet(base, initialPath, value, options = {}) {
-  const { withArrays = false, equality } = options;
+  const { withArrays = false, equality, safe } = options;
   let path = initialPath;
 
   if (typeof path === 'string' && path.length > 0) {
@@ -66,7 +66,7 @@ export default function safeSet(base, initialPath, value, options = {}) {
   }
 
   // If the value is already here we just need to return the base
-  if (recursiveEqual(base, path, value, equality)) {
+  if (safe && recursiveEqual(base, path, value, equality)) {
     return base;
   }
 

--- a/tests/set.spec.js
+++ b/tests/set.spec.js
@@ -88,7 +88,7 @@ describe('set', () => {
 
   it('should not modify the base if the value is already there', () => {
     const foo = { a: { b: [3] } };
-    expect(set(foo, ['a', 'b', 0], 3)).toBe(foo);
+    expect(set(foo, ['a', 'b', 0], 3, { safe: true })).toBe(foo);
   });
 
   it('should reform object', () => {
@@ -114,12 +114,14 @@ describe('set', () => {
 
     const equality = (a, b) => a.id === b.id && a.version === b.version;
 
-    expect(set(base, ['a', 0], { id: 1, version: 1 }, { withArrays: true, equality })).toBe(base);
-    expect(set(base, ['a', 0], { id: 1, version: 1, foo: 'foo' }, { withArrays: true, equality })).toBe(base);
-    expect(set(base, ['a', 0], { id: 1 }, { withArrays: true, equality })).toEqual({
+    expect(set(base, ['a', 0], { id: 1, version: 1 }, { withArrays: true, equality, safe: true })).toBe(base);
+    expect(set(base, ['a', 0], { id: 1, version: 1, foo: 'foo' }, { withArrays: true, equality, safe: true })).toBe(
+      base,
+    );
+    expect(set(base, ['a', 0], { id: 1 }, { withArrays: true, equality, safe: true })).toEqual({
       a: [{ id: 1 }, { id: 2, foo: 'foobar', version: 1 }],
     });
-    expect(set(base, ['a', 1], { id: 1, foo: 'bar', version: 1 }, { withArrays: true, equality })).toEqual({
+    expect(set(base, ['a', 1], { id: 1, foo: 'bar', version: 1 }, { withArrays: true, equality, safe: true })).toEqual({
       a: [{ id: 1, foo: 'bar', version: 1 }, { id: 1, foo: 'bar', version: 1 }],
     });
   });

--- a/tests/set.spec.js
+++ b/tests/set.spec.js
@@ -3,7 +3,7 @@ import set from '../src/set';
 
 jest.unmock('../src/set.js');
 
-describe('set', () => {
+describe('simple set', () => {
   it('should assign to object path without mutating', () => {
     // Given
     const obj = freeze({ foo: { bar: 2 } });
@@ -124,5 +124,104 @@ describe('set', () => {
     expect(set(base, ['a', 1], { id: 1, foo: 'bar', version: 1 }, { withArrays: true, equality, safe: true })).toEqual({
       a: [{ id: 1, foo: 'bar', version: 1 }, { id: 1, foo: 'bar', version: 1 }],
     });
+  });
+});
+
+describe('multiple set', () => {
+  it('should set objects in object with object sub values', () => {
+    const base = freeze({
+      a: {
+        b: {
+          1: { id: 1 },
+          2: { id: 2 },
+          3: { id: 3 },
+        },
+      },
+    });
+
+    const expected = {
+      a: {
+        b: {
+          1: { id: 1 },
+          2: { id: 2, foo: 'bar' },
+          3: { id: 3 },
+          4: { id: 4 },
+          c: { id: 'c' },
+        },
+      },
+    };
+
+    const path = ['a', 'b', ['2', '4', 'c']];
+    const values = { 2: { id: 2, foo: 'bar' }, 4: { id: 4 }, c: { id: 'c' } };
+
+    expect(set(base, path, values)).toEqual(expected);
+  });
+
+  it('should set objects in object with array sub values', () => {
+    const base = freeze({
+      a: {
+        b: {
+          1: { id: 1 },
+          2: { id: 2 },
+          3: { id: 3 },
+        },
+      },
+    });
+
+    const expected = {
+      a: {
+        b: {
+          1: { id: 1 },
+          2: { id: 2, foo: 'bar' },
+          3: { id: 3 },
+          4: { id: 4 },
+          c: { id: 'c' },
+        },
+      },
+    };
+
+    const path = ['a', 'b', ['2', '4', 'c']];
+    const values = [{ id: 2, foo: 'bar' }, { id: 4 }, { id: 'c' }];
+
+    expect(set(base, path, values)).toEqual(expected);
+  });
+
+  it('should throw an error when trying to set objects in array with object sub values', () => {
+    const base = freeze({
+      a: {
+        b: [{ id: 1 }, { id: 2 }, { id: 3 }],
+      },
+    });
+
+    const path = ['a', 'b', [1, 3, 8]];
+    const values = { 1: { id: 2, foo: 'bar' }, 3: { id: 4 }, 8: { id: 'c' } };
+
+    try {
+      set(base, path, values);
+      expect(false)
+        .toBeTruthy()
+        .as('Error should have been raised');
+    } catch (err) {
+      expect(err.message).toBe('Can not use object values with array in path');
+    }
+  });
+
+  it('should set objects in array with array sub values', () => {
+    const base = freeze({
+      a: {
+        b: [{ id: 1 }, { id: 2 }, { id: 3 }],
+      },
+    });
+
+    const expected = {
+      a: {
+        b: [{ id: 1 }, { id: 2, foo: 'bar' }, { id: 3 }, { id: 4 }, { id: 'c' }],
+      },
+    };
+
+    const path = ['a', 'b', [1, 3, 8]];
+    const values = [{ id: 2, foo: 'bar' }, { id: 4 }, { id: 'c' }];
+
+    expect(set(base, path, values)).toEqual(expected);
   });
 });

--- a/tests/set.spec.js
+++ b/tests/set.spec.js
@@ -21,7 +21,7 @@ describe('set', () => {
     const array = freeze(['foo', ['bar', 'baz']]);
 
     // When
-    const result = set(array, [1, 0], 'qux', true);
+    const result = set(array, [1, 0], 'qux', { withArrays: true });
 
     // Then
     expect(result).not.toBe(array);
@@ -57,7 +57,7 @@ describe('set', () => {
     const array = freeze([]);
 
     // When
-    const result = set(array, [0, 'foo'], 'bar', true);
+    const result = set(array, [0, 'foo'], 'bar', { withArrays: true });
 
     // Then
     expect(result).not.toBe(array);
@@ -69,7 +69,7 @@ describe('set', () => {
     const array = freeze([]);
 
     // When
-    const result = set(array, [0, 0], 'qux', true);
+    const result = set(array, [0, 0], 'qux', { withArrays: true });
 
     // Then
     expect(result).not.toBe(array);
@@ -83,7 +83,7 @@ describe('set', () => {
 
   it('should use an array as structure when specified', () => {
     const foo = freeze({ key: 3 });
-    expect(set({}, ['a', foo.key], 'foo', true)).toEqual({ a: ['foo'] });
+    expect(set({}, ['a', foo.key], 'foo', { withArrays: true })).toEqual({ a: ['foo'] });
   });
 
   it('should not modify the base if the value is already there', () => {
@@ -96,15 +96,15 @@ describe('set', () => {
     expect(set(null, [], 3)).toBe(3);
     expect(set(null, '', 3)).toBe(3);
     expect(set(null, ['list', 0], 3)).toEqual({ list: { '0': 3 } });
-    expect(set(null, ['list', 0], 3, true)).toEqual({ list: [3] });
+    expect(set(null, ['list', 0], 3, { withArrays: true })).toEqual({ list: [3] });
   });
 
   it('should use string path', () => {
     expect(set(null, 'a.b', 3)).toEqual({ a: { b: 3 } });
     expect(set(null, 'list[0]', 3)).toEqual({ list: { 0: 3 } });
-    expect(set(null, 'list[0]', 3, true)).toEqual({ list: [3] });
-    expect(set(null, 'a.list[0]', 3, true)).toEqual({ a: { list: [3] } });
-    expect(set(null, 'a[0].b', 42, true)).toEqual({ a: [{ b: 42 }] });
+    expect(set(null, 'list[0]', 3, { withArrays: true })).toEqual({ list: [3] });
+    expect(set(null, 'a.list[0]', 3, { withArrays: true })).toEqual({ a: { list: [3] } });
+    expect(set(null, 'a[0].b', 42, { withArrays: true })).toEqual({ a: [{ b: 42 }] });
   });
 
   it('should use equality function', () => {
@@ -114,12 +114,12 @@ describe('set', () => {
 
     const equality = (a, b) => a.id === b.id && a.version === b.version;
 
-    expect(set(base, ['a', 0], { id: 1, version: 1 }, true, equality)).toBe(base);
-    expect(set(base, ['a', 0], { id: 1, version: 1, foo: 'foo' }, true, equality)).toBe(base);
-    expect(set(base, ['a', 0], { id: 1 }, true, equality)).toEqual({
+    expect(set(base, ['a', 0], { id: 1, version: 1 }, { withArrays: true, equality })).toBe(base);
+    expect(set(base, ['a', 0], { id: 1, version: 1, foo: 'foo' }, { withArrays: true, equality })).toBe(base);
+    expect(set(base, ['a', 0], { id: 1 }, { withArrays: true, equality })).toEqual({
       a: [{ id: 1 }, { id: 2, foo: 'foobar', version: 1 }],
     });
-    expect(set(base, ['a', 1], { id: 1, foo: 'bar', version: 1 }, true, equality)).toEqual({
+    expect(set(base, ['a', 1], { id: 1, foo: 'bar', version: 1 }, { withArrays: true, equality })).toEqual({
       a: [{ id: 1, foo: 'bar', version: 1 }, { id: 1, foo: 'bar', version: 1 }],
     });
   });


### PR DESCRIPTION
⚠️  This is a breaking change, the function now takes a config object instead of `withArrays` and `equality` parameters

 - [x] add the possibility to set multiple elements at once
 - [x] tests
 - [x] update documentation


