### PR TITLE
feat(multiple set): add option to use the same value for all values of the multiple set

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ name | description | type | default
 withArray | if set to `true` number will be interpreted has array indexes | boolean | false
 equality  | if provided, the function will be used to determine if the value at the path is equal to the value provided | function | `===`
 safe | verify if the value does not already exist | boolean | false
+sameValue | use same value for each nested property in case of multi set | boolean | false
 
 
 ## Usage
@@ -101,16 +102,20 @@ set(base, 'a', { id: 1, v: 1 }, { safe: true, equality);
 
 ### multiple set
 It is possible to set multiple elements at once, providing multiple keys in the path and an array (or an object) in value.
+
 ```js
 set({}, ['a', ['b', 'c']], [12, 13]);
 // or
 set({}, ['a', ['b', 'c']], { b: 12, c: 13 });
 // will return { a: { b: 12, c: 13 } }
 
-
 set({}, ['a', [0, 1 ]], [12, 13], { withArrays: true });
 // will return { a: [12, 13] }
+```
 
+It's also possible to set multiple elements at once with the same value by setting `sameValue: true` in options.
+
+```js
 set({}, ['a', ['b', 'c']], { foo: 'bar' }, { sameValue: true });
 // will return { a: { b: { foo: 'bar' }, c: { foo: 'bar' } } }
 

--- a/README.md
+++ b/README.md
@@ -110,6 +110,12 @@ set({}, ['a', ['b', 'c']], { b: 12, c: 13 });
 
 set({}, ['a', [0, 1 ]], [12, 13], { withArrays: true });
 // will return { a: [12, 13] }
+
+set({}, ['a', ['b', 'c']], { foo: 'bar' }, { sameValue: true });
+// will return { a: { b: { foo: 'bar' }, c: { foo: 'bar' } } }
+
+set({}, ['a', [0, 1 ]], 'foo', { withArrays: true, sameValue: true });
+// will return { a: ['foo', 'foo'] }
 ```
 - :warning: If the array of keys is not the last element of the path, the rest of the path will be used for each sub tree.
 - :warning: It's not possible to set objects in array with object sub values, this will throw an error.

--- a/tests/set.spec.js
+++ b/tests/set.spec.js
@@ -157,6 +157,35 @@ describe('multiple set', () => {
     expect(set(base, path, values)).toEqual(expected);
   });
 
+  it('should set objects in object with same object sub value', () => {
+    const base = freeze({
+      a: {
+        b: {
+          1: { id: 1 },
+          2: { id: 2 },
+          3: { id: 3 },
+        },
+      },
+    });
+
+    const expected = {
+      a: {
+        b: {
+          1: { id: 1 },
+          2: { foo: 'bar' },
+          3: { id: 3 },
+          4: { foo: 'bar' },
+          c: { foo: 'bar' },
+        },
+      },
+    };
+
+    const path = ['a', 'b', ['2', '4', 'c']];
+    const value = { foo: 'bar' };
+
+    expect(set(base, path, value, { sameValue: true })).toEqual(expected);
+  });
+
   it('should set objects in object with array sub values', () => {
     const base = freeze({
       a: {
@@ -223,5 +252,24 @@ describe('multiple set', () => {
     const values = [{ id: 2, foo: 'bar' }, { id: 4 }, { id: 'c' }];
 
     expect(set(base, path, values)).toEqual(expected);
+  });
+
+  it('should set objects in array with same array sub value', () => {
+    const base = freeze({
+      a: {
+        b: [{ id: 1 }, { id: 2 }, { id: 3 }],
+      },
+    });
+
+    const expected = {
+      a: {
+        b: [{ id: 1 }, { foo: 'bar' }, { id: 3 }, { foo: 'bar' }, { foo: 'bar' }],
+      },
+    };
+
+    const path = ['a', 'b', [1, 3, 8]];
+    const value = { foo: 'bar' };
+
+    expect(set(base, path, value, { sameValue: true })).toEqual(expected);
   });
 });


### PR DESCRIPTION
Add option to use the same value for all values of the multiple set.

```js
set({}, ['a', ['b', 'c']], { foo: 'bar' }, { sameValue: true });
// will return { a: { b: { foo: 'bar' }, c: { foo: 'bar' } } }

set({}, ['a', [0, 1 ]], 'foo', { withArrays: true, sameValue: true });
// will return { a: ['foo', 'foo'] }
```
